### PR TITLE
Disabling of pick and reset buttons

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -22,6 +22,8 @@ function previewImages() {
 }
 
 function pickRandomImage() {
+    $("#reset-button").prop('disabled', false);
+    $("#pick-button").prop('disabled', true);
     if (!IMAGES.length) {
         $("#information-text").html("No images left");
         $("#random-image").html("");
@@ -47,6 +49,7 @@ function doCarousel(index, durations) {
         data = `<img class="img-thumbnail random-image" src="` + IMAGES[index] + `">`;
         $("#random-image").html(data);
         IMAGES.splice(index, 1);
+        $("#pick-button").prop('disabled', false);
     }
 }
 
@@ -95,6 +98,7 @@ function previousStep() {
         });
         clearStep(CURRENT_STEP);
         CURRENT_STEP--;
+        $("#reset-button").prop('disabled', true);
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
           <div class="col-lg-12 text-center">
             <h1 class="mt-3 mb-3">Random image picker</h1>
             <p id="information-text" class="step-2-clear"></p>
-            <button type="button" class="btn btn-success" onclick="pickRandomImage();">Pick random image</button>
-            <button type="button" class="btn btn-warning" onclick="previousStep();">Reset images</button>
+            <button id="pick-button" type="button" class="btn btn-success" onclick="pickRandomImage();">Pick random image</button>
+            <button id="reset-button" type="button" class="btn btn-warning" disabled onclick="previousStep();">Reset images</button>
             <div id="random-image" class="step-2-clear h-55 mt-5"></div>
           </div>
         </div>


### PR DESCRIPTION
Disable pick button while carousel is running. Added benefit is that it provides a clue to when the carousel is finished.

Disable reset button until pick button is clicked.